### PR TITLE
feat(bookings): integrate catalog add-ons into booking creation

### DIFF
--- a/backend/src/dto/bookingDTO.ts
+++ b/backend/src/dto/bookingDTO.ts
@@ -180,6 +180,10 @@ export const CreateBookingDTO = BookingDTO.omit({
       .transform((val) => Number(val))
       .optional()
   ),
+  catalogAddOnIds: z.array(z.number().int()).optional().default([]).openapi({
+    description: "Array of catalog add-on IDs to be included in the booking",
+    example: [1, 2, 3],
+  })
   // hasRescheduled: z.preprocess(
   //   (val) => (val === null ? 0 : val), // Convert null to 0
   //   z


### PR DESCRIPTION
- Added support for `catalogAddOnIds` during booking creation.
- Validates `catalogAddOnIds` as a non-empty array and fetches corresponding add-on details.
- Computes `addOnsTotal` and includes it in `baseAmount` for total booking cost calculation.
- Adjusts final `totalAmount` by applying discount to base + add-ons + additional guest fee.
- Persists selected add-ons into `BookingAddOnsTable` with their prices linked to the booking.